### PR TITLE
reenable incrementals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>pipeline-github-2.6</tag>
+        <tag>${scmTag}</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
during the `[maven-release-plugin] prepare for next development iteration` commit the version was just increased and not set back to `${scmTag}`